### PR TITLE
Update use of source_code_hash for Terraform 0.11.12 and later

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -88,7 +88,7 @@ resource "aws_lambda_function" "rotate-code-mysql" {
   function_name      = "${var.name}-${var.filename}"
   role               = "${aws_iam_role.lambda_rotation.arn}"
   handler            = "lambda_function.lambda_handler"
-  source_code_hash   = "${base64sha256(file("${path.module}/${var.filename}.zip"))}"
+  source_code_hash   = filebase64sha256("${path.module}/${var.filename}.zip")
   runtime            = "python2.7"
   vpc_config {
     subnet_ids         = "${var.subnets_lambda}"


### PR DESCRIPTION
- Updated source_code_hash used in the rorate-code-mysql lambda for Terraform 0.11.12 & Later
- replaced interpolation with HLC2 expression 